### PR TITLE
fixing mktemp for OSX

### DIFF
--- a/git_split.sh
+++ b/git_split.sh
@@ -10,7 +10,7 @@
 SRC_REPO=$1
 SRC_DIR=$2
 OUTPUT_REPO=$3
-TMP_DIR=$(mktemp -d)
+TMP_DIR=$(mktemp -d git_split)
 
 REPO_BASE=$TMP_DIR/repo_base;
 REPO_TMP=$TMP_DIR/repo_tmp;


### PR DESCRIPTION
mktemp on mac requires a prefix